### PR TITLE
fixes  issue #2 Race condition by adding an optional createCollectionCallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ const mongoCachePromise = () => {
 };
 
 
-this.mongoCachePromise.then((mongoCache) => {
+mongoCachePromise.then((mongoCache) => {
   return mongoCache.wrap(key, () => {
     return getUser(userId);
   });

--- a/README.md
+++ b/README.md
@@ -79,6 +79,42 @@ mongoCache.wrap(key, function (cb) {
         console.log(user);
     });
 });
+
+// using promises with createCollectionCallback that handles race conditions.
+const mongoCachePromise = () => {
+  return new Promise((resolve) => {
+    const mongoCache = cacheManager.caching({
+      store: mongoStore,
+      uri: 'mongodb://localhost:27017/nodeCacheDb',
+      options: {
+        host: '127.0.0.1',
+        port: '27017',
+
+        // username: 'username',
+        // password: 'pass',
+        database: 'nodeCacheDb',
+        collection: 'cacheManager',
+        compression: false,
+        server: {
+          poolSize: 5,
+          auto_reconnect: true,
+        },
+      },
+      createCollectionCallback: () => {
+        console.log('done creating collection');
+        return resolve(mongoCache);
+      },
+    });
+  });
+};
+
+
+this.mongoCachePromise.then((mongoCache) => {
+  return mongoCache.wrap(key, () => {
+    return getUser(userId);
+  });
+});
+
 ```
 
 ### Multi-store

--- a/index.js
+++ b/index.js
@@ -77,6 +77,8 @@ function MongoStore(args) {
         }, function (err, indexName) {
           if (err) {
             console.log("Error During Indexes creation");
+          } else if ('function' === typeof args.createCollectionCallback){
+            args.createCollectionCallback(store);
           }
         });
       });


### PR DESCRIPTION
I fixed  issue #2 Race condition by adding an optional createCollectionCallback that is called after the MongoDb Client has connected, the collection created, and the index created.

This is similar to https://github.com/hotelde/node-cache-manager-fs fillcallback option.

Sample usage added to README.md:

const mongoCachePromise = () => {
  return new Promise((resolve) => {
    const mongoCache = cacheManager.caching({
      store: mongoStore,
      uri: 'mongodb://localhost:27017/nodeCacheDb',
      options: {
        host: '127.0.0.1',
        port: '27017',

```
    // username: 'username',
    // password: 'pass',
    database: 'nodeCacheDb',
    collection: 'cacheManager',
    compression: false,
    server: {
      poolSize: 5,
      auto_reconnect: true,
    },
  },
  createCollectionCallback: () => {
    console.log('done creating collection');
    return resolve(mongoCache);
  },
});
```

  });
};

mongoCachePromise.then((mongoCache) => {
  return mongoCache.wrap(key, () => {
    return getUser(userId);
  });
});
