### PR TITLE
fix Warning: Top-level use of w, wtimeout, j, and fsync is deprecated. Use writeConcern instead.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,12 @@ const validOptionNames = ['poolSize', 'ssl', 'sslValidate', 'sslCA', 'sslCert',
   'sslKey', 'sslPass', 'sslCRL', 'autoReconnect', 'noDelay', 'keepAlive', 'connectTimeoutMS', 'family',
   'socketTimeoutMS', 'reconnectTries', 'reconnectInterval', 'ha', 'haInterval',
   'replicaSet', 'secondaryAcceptableLatencyMS', 'acceptableLatencyMS',
-  'connectWithNoPrimary', 'authSource', 'w', 'wtimeout', 'j', 'forceServerObjectId',
+  'connectWithNoPrimary', 'authSource', 'forceServerObjectId',
   'serializeFunctions', 'ignoreUndefined', 'raw', 'bufferMaxEntries',
   'readPreference', 'pkFactory', 'promiseLibrary', 'readConcern', 'maxStalenessSeconds',
   'loggerLevel', 'logger', 'promoteValues', 'promoteBuffers', 'promoteLongs',
   'domainsEnabled', 'keepAliveInitialDelay', 'checkServerIdentity', 'validateOptions', 'appname', 'auth', 'useNewUrlParser',
-  'useUnifiedTopology'
+  'useUnifiedTopology', 'writeConcern'
 ];
 
 
@@ -39,6 +39,7 @@ class MongoStore {
     store.MongoOptions.promiseLibrary = Promise;
     store.MongoOptions.useNewUrlParser = true;
     store.MongoOptions.useUnifiedTopology = true;
+    store.MongoOptions.writeConcern = {w: 0};
     store.name = 'mongodb';
     store.expireKey = 'expire';
     store.coll = store.MongoOptions.collection || 'cacheman';
@@ -238,7 +239,6 @@ class MongoStore {
     };
     const opt = {
       upsert: true,
-      w: 1
     };
     store.getCollection()
       .then((collection) => {

--- a/package.json
+++ b/package.json
@@ -20,16 +20,16 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.5.3",
-    "cache-manager": "^2.9.0",
+    "cache-manager": "^3.4.3",
     "lodash": "^4.17.15",
-    "mongodb": "^3.6.3"
+    "mongodb": "^3.6.6"
   },
   "devDependencies": {
     "cache-manager": "^3.4.0",
     "grunt": "^1.0.4",
-    "grunt-contrib-jshint": "^2.0.0",
+    "grunt-contrib-jshint": "^3.0.0",
     "jshint-stylish": "^2.2.1",
-    "load-grunt-tasks": "^4.0.0",
+    "load-grunt-tasks": "^5.1.0",
     "mocha": "^8.2.1"
   }
 }


### PR DESCRIPTION
Hi, i try update outdated depedency and try to solve warning deprecated w, wtimeout, j, and synch using [writeConcern](https://docs.mongodb.com/manual/reference/write-concern/) mongoDB.
